### PR TITLE
PKG-14955: rebuild qdldl-python 0.1.7.post5 against pybind11 3.0.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - patches/0004-Do-not-pass-CMAKE_GENERATOR-as-variable.patch
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,7 @@ requirements:
     - libqdldl {{ libqdldl }}
     - numpy {{ numpy  }}
     - pybind11
+    - pybind11-abi
   run:
     - python
     - numpy >=1.7


### PR DESCRIPTION
qdldl-python 0.1.7.post5

**Destination channel:** Defaults

### Links

- [PKG-14955](https://anaconda.atlassian.net/browse/PKG-14955)
- [PKG-13552](https://anaconda.atlassian.net/browse/PKG-13552) (parent epic)
- Relevant dependency PRs:
  - AnacondaRecipes/pybind11-feedstock#24 (pybind11 3.0.4 — **MERGED**)
  - AnacondaRecipes/repodata-hotfixes#318 (scope reduction — **applied**)

### Explanation of changes:

- **Build number 0 -> 1** (no source change). Rebuild against pybind11 3.0.4 from pkgs/main.
- **Result:** the new artifact will declare `pybind11-abi ==11` via pybind11-abi's run_export.
- **Why:** qdldl-python participates in cross-module C++ type exchange with cvxpy (LDL factorization handles passed across module boundaries). Per Charles's PKG-13552 hotfix-scope analysis, retained in the slim `MISSING_PYBIND11_ABI_VERSION_RANGES` table after #318.

[PKG-14955]: https://anaconda.atlassian.net/browse/PKG-14955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13552]: https://anaconda.atlassian.net/browse/PKG-13552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ